### PR TITLE
Use jekyll-redirect-from plugin for older films redirect

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ url: "https://www.paulzinder.com" # the base hostname & protocol for your site, 
 plugins:
   - jekyll-feed
   - jekyll-sitemap
+  - jekyll-redirect-from
 
 # Exclude from processing.
 # The following items will not be processed, by default.
@@ -68,5 +69,3 @@ github:
   - metadata
 exclude:
   - send-email
-gems:
-  - jekyll-redirect-from

--- a/films.md
+++ b/films.md
@@ -2,4 +2,6 @@
 title: Films
 layout: films
 permalink: /films/
+redirect_from:
+  - /films/older-films/
 ---

--- a/older-films.md
+++ b/older-films.md
@@ -1,4 +1,0 @@
----
-permalink: /films/older-films
-redirect_to: "https://www.paulzinder.com/films/"
----


### PR DESCRIPTION
Switch to using `jekyll-redirect-from` plugin for old urls as the gem did not play nicely with `jekyll-sitemap`