### PR TITLE
Add yearly GitHub pages refresh

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,0 +1,19 @@
+name: Pages Refresh
+
+on:
+  schedule:
+    - cron: "0 0 1 1 *" # Runs every new year, on January 1 at 1am
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger GitHub pages rebuild
+        run: |
+          curl --fail --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/pages/builds \
+            --header "Authorization: Bearer $PERSONAL_ACCESS_TOKEN"
+        env:
+          # You must create a personal token with repo access as GitHub does
+          # not yet support server-to-server page builds.
+          USER_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -12,7 +12,7 @@ jobs:
         run: |
           curl --fail --request POST \
             --url https://api.github.com/repos/${{ github.repository }}/pages/builds \
-            --header "Authorization: Bearer $PERSONAL_ACCESS_TOKEN"
+            --header "Authorization: Bearer $USER_TOKEN"
         env:
           # You must create a personal token with repo access as GitHub does
           # not yet support server-to-server page builds.


### PR DESCRIPTION
Trigger pages build at beginning of new year to update dates on the static site