### PR TITLE
Update "Some Stiff Competition" festivals

### DIFF
--- a/_films/2022-01-01-some-stiff-competition.md
+++ b/_films/2022-01-01-some-stiff-competition.md
@@ -30,8 +30,8 @@ formats:
 length: 15 min.
 language: English
 selected_screenings:
-  - name: Hollyshorts Film Festival Monthly Screening Series
-    location: Hollywood, CA
+  - name: Aporia International Village Film Festival
+    location: South Korea
     year: 2023
     type: festival
   - name: Berkeley Springs Film Festival
@@ -44,6 +44,10 @@ selected_screenings:
     type: festival
   - name: East Lansing Film Festival
     location: Michigan
+    year: 2022
+    type: festival
+  - name: Hardwick Gallery
+    location: Cheltenham, UK
     year: 2022
     type: festival
   - name: No Coast Film Fest


### PR DESCRIPTION
- Cut the HollyShorts Film Festival from the top of the list
- Add the Aporia International Village Film Festival (South Korea) 2023 to the top
- Add Hardwick Gallery (Cheltenham, UK) 2022 after the East Lansing Film Festival