### PR TITLE
Remove links to videos

### DIFF
--- a/_films/2007-01-01-uno-degli-ultimi.md
+++ b/_films/2007-01-01-uno-degli-ultimi.md
@@ -8,7 +8,6 @@ alternate_title: Uno degli Ultimi
 image:
   name: 'assets/images/2011/06/uno_degli_ultimi_2'
   extension: jpg
-vimeo_id: 153887531
 synopsis: >-
   Mauro is a 78-year-old Italian farmer who loves his life. He picks olives,
   grapes, cherries.  He wonders why anybody would want to do anything else.

--- a/_films/2009-01-01-benedizione-delle-bestie.md
+++ b/_films/2009-01-01-benedizione-delle-bestie.md
@@ -9,7 +9,6 @@ alternate_title: Benedizione delle Bestie
 image:
   name: 'assets/images/2011/06/Picture-1'
   extension: jpg
-vimeo_id: 153887941
 synopsis: >-
   Each January, on the steps of a 5th century church in Rome’s most derelict
   neighborhood, people bring their pets to participate in an ancient rite.

--- a/_films/2011-01-01-robot-and-pinocchi.md
+++ b/_films/2011-01-01-robot-and-pinocchi.md
@@ -8,7 +8,6 @@ alternate_title: Robot e Pinocchi
 image:
   name: 'assets/images/2011/06/CU-Horse-head'
   extension: jpg
-vimeo_id: 153889437
 synopsis: >-
   Italian sculptor Ferdinando Codognotto shapes wood into his personal
   philosophy. We are all robots and pinocchios.

--- a/_films/2015-01-01-signwriter.md
+++ b/_films/2015-01-01-signwriter.md
@@ -8,7 +8,6 @@ layout: film
 image:
   name: 'assets/images/2011/06/Signwriter-by-Paul-Zinder-still'
   extension: jpg
-vimeo_id: 134313805
 synopsis: >-
   This short, commissioned by the UK’s Canal and River Trust, is a portrait of
   Graham Brown, a painter of canal boats on Gloucester’s docks. For sixty years,

--- a/_films/2022-01-01-some-stiff-competition.md
+++ b/_films/2022-01-01-some-stiff-competition.md
@@ -15,7 +15,6 @@ layout: film
 image:
   name: 'assets/images/2022/01/some-stiff-competition-00'
   extension: jpg
-vimeo_id: 765794424
 synopsis: >-
   This short follows two local families, led by a dad and a granddad (one a
   former champion), as they compete in a local event where their village’s


### PR DESCRIPTION
This pull request removes the `vimeo_id` field from several film markdown files in the `_films` directory. The main purpose is to clean up metadata by eliminating the Vimeo video ID references from these film entries.